### PR TITLE
Fixed config-interval prop type checking in basertpendpoint

### DIFF
--- a/src/gst-plugins/commons/kmsbasertpendpoint.c
+++ b/src/gst-plugins/commons/kmsbasertpendpoint.c
@@ -1218,7 +1218,7 @@ kms_base_rtp_endpoint_get_payloader_for_caps (GstCaps * caps)
   pspec =
       g_object_class_find_property (G_OBJECT_GET_CLASS (payloader),
       "config-interval");
-  if (pspec != NULL && G_PARAM_SPEC_VALUE_TYPE (pspec) == G_TYPE_UINT) {
+  if (pspec != NULL && G_PARAM_SPEC_VALUE_TYPE (pspec) == G_TYPE_INT) {
     g_object_set (payloader, "config-interval", 1, NULL);
   }
 


### PR DESCRIPTION
The property was changed from type `G_UINT` to `G_INT` (to support the value -1 for SPS/PPS at every IDR slice), but the proptype checking in `kmsbasertpendpoint` was not updated accordingly.