### PR TITLE
Ported `Add support for rtcp-fb fir`

### DIFF
--- a/src/gst-plugins/commons/constants.h
+++ b/src/gst-plugins/commons/constants.h
@@ -23,6 +23,7 @@
 #define SDP_MEDIA_RTCP_FB_GOOG_REMB "goog-remb"
 #define SDP_MEDIA_RTCP_FB_PLI "pli"
 #define SDP_MEDIA_RTCP_FB_FIR "fir"
+#define SDP_MEDIA_RTCP_FB_FIR_TMMBR "ccm fir tmmbr"
 
 /* RTP Header Extensions */
 #define RTP_HDR_EXT_ABS_SEND_TIME_URI "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"

--- a/src/gst-plugins/commons/kmsutils.c
+++ b/src/gst-plugins/commons/kmsutils.c
@@ -463,7 +463,7 @@ discont_detection_probe (GstPad * pad, GstPadProbeInfo * info, gpointer data)
   if (GST_BUFFER_FLAG_IS_SET (buffer, GST_BUFFER_FLAG_DISCONT)) {
     if (GST_BUFFER_FLAG_IS_SET (buffer, GST_BUFFER_FLAG_DELTA_UNIT)) {
       GST_WARNING_OBJECT (pad, "Stream discontinuity detected on non-keyframe");
-      kms_utils_drop_until_keyframe (pad, FALSE);
+      kms_utils_drop_until_keyframe (pad, TRUE);
 
       return GST_PAD_PROBE_DROP;
     }


### PR DESCRIPTION
Backported some work from the GTMCU folks for TMMBR FIR detection.
I meddled with the cherry-pick commit and also re-added the rtcp-fb pli detection and moved constants to be up to date with the upstream version.