### PR TITLE
Leave source sync and timestamps adjustments to rtpbin/jitterbuffer

### DIFF
--- a/src/gst-plugins/commons/kmsutils.c
+++ b/src/gst-plugins/commons/kmsutils.c
@@ -1422,7 +1422,7 @@ kms_utils_depayloader_adjust_pts_out (AdjustPtsData * data, GstBuffer * buffer)
       && pts_current <= data->last_pts) {
     pts_fixed = data->last_pts + GST_MSECOND;
 
-    GST_WARNING_OBJECT (data->element, "Fix PTS not strictly increasing"
+    GST_INFO_OBJECT (data->element, "Fix PTS not strictly increasing"
         ", last: %" GST_TIME_FORMAT
         ", current: %" GST_TIME_FORMAT
         ", fixed = last + 1: %" GST_TIME_FORMAT,


### PR DESCRIPTION
Cherry-pick @mariogasparoni 's commit to deactivate the rtpsynchronizer.
This fixes an issue with some recordings and streams which had their PTS values incorrectly zeroed and
rewritten, plus what's written below.

```
We do not try to interpolate current timestamp (in kmsrtpsyncrhonizer) until we receive sender report packets anymore (this wasn't being done though).
We also slave receiver clock to sender's clock in jitterbuffer (default jitterbuffer mode)
We still keep the timestamp adjustment (when PTS does not increase) in depayloader's src pad
This prevent high jitterbuffer clock skew when sending dtmf from some endpoints (such as polycom), which results in audio high latency or packet drop
This also gives the application a better timestamp handling when there are gaps or high clock skew
```