### PR TITLE
Remove the caps fixation in agnosticbin check_bin

### DIFF
--- a/src/gst-plugins/kmsagnosticbin.c
+++ b/src/gst-plugins/kmsagnosticbin.c
@@ -506,16 +506,6 @@ check_bin (KmsTreeBin * tree_bin, const GstCaps * caps)
     gst_caps_set_features (temp_raw_caps, 0,
         gst_caps_features_new_empty ());
 
-    // Check if caps are already fixed before trying to intersect them. If not,
-    // fixate them
-    if (!gst_caps_is_fixed (temp_raw_caps)) {
-      temp_raw_caps = gst_caps_fixate (temp_raw_caps);
-    }
-
-    if (!gst_caps_is_fixed (current_caps)) {
-      current_caps = gst_caps_fixate (current_caps);
-    }
-
     // Remove some trailing caps fields to avoid triggering the creation of a
     // new treebin without a proper reason
     GstStructure *st1, *st2;


### PR DESCRIPTION
Turns out the caps fixation brought more problems than it solved, mainly causing some unwanted transcoding with audio streams due to channel number mismatches.
Reverting it. Shouldn't cause any regression other than fixing some transcoding issues.