### PR TITLE
Change basertpendpoint jitterbuffer mode from 1 to 4

### DIFF
--- a/src/gst-plugins/commons/kmsbasertpendpoint.c
+++ b/src/gst-plugins/commons/kmsbasertpendpoint.c
@@ -2013,7 +2013,7 @@ kms_base_rtp_endpoint_rtpbin_new_jitterbuffer (GstElement * rtpbin,
   KmsRTPSessionStats *rtp_stats;
   KmsSSRCStats *ssrc_stats;
 
-  g_object_set (jitterbuffer,
+  g_object_set (jitterbuffer, "mode", 4 /* synced */ ,
       "latency", JB_INITIAL_LATENCY, "drop-on-latency", TRUE, NULL);
 
   switch (session) {


### PR DESCRIPTION
Improves audio/video quality by syncing sender and receiver clocks instead of slaving the receiver to the sender